### PR TITLE
feat: Add Python library for PCA9685

### DIFF
--- a/examples/simple_test.py
+++ b/examples/simple_test.py
@@ -1,0 +1,43 @@
+import time
+from pca9685 import PCA9685
+
+# Mock I2C class for testing without hardware
+class MockI2C:
+    def writeto_mem(self, address, register, buffer):
+        print(f"I2C Write to Address: {hex(address)}, Register: {hex(register)}, Data: {list(buffer)}")
+
+    def readfrom_mem(self, address, register, size):
+        print(f"I2C Read from Address: {hex(address)}, Register: {hex(register)}, Size: {size}")
+        if register == 0x00: # MODE1
+            return bytearray([0x10]) # Return SLEEP bit set
+        return bytearray([0x00] * size)
+
+def main():
+    # Initialize I2C bus
+    i2c = MockI2C()
+
+    # Initialize PCA9685
+    pca = PCA9685(i2c)
+
+    # Set PWM frequency to 60hz
+    pca.set_pwm_freq(60)
+
+    # Set a PWM channel to a specific value
+    # For example, channel 0 with a 50% duty cycle
+    # The PCA9685 has 4096 steps (12-bit)
+    # 50% of 4096 is 2048
+    channel = 0
+    on_tick = 0
+    off_tick = 2048
+    pca.set_pwm(channel, on_tick, off_tick)
+    print(f"Set PWM for channel {channel} to on: {on_tick}, off: {off_tick}")
+
+    time.sleep(1)
+
+    # Set all PWM channels to off
+    pca.set_all_pwm(0, 0)
+    print("All PWM channels turned off.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pca9685/README.md
+++ b/pca9685/README.md
@@ -1,0 +1,50 @@
+# PCA9685 Python Library
+
+This is a Python library for the NXP PCA9685 16-channel, 12-bit PWM I2C-bus LED/servo driver.
+
+## Features
+
+- Set PWM frequency for all channels.
+- Set PWM duty cycle for individual channels.
+
+## Usage
+
+Here is a simple example of how to use the library:
+
+```python
+import time
+from pca9685 import PCA9685
+from smbus2 import SMBus
+
+def main():
+    # Initialize I2C bus
+    bus = SMBus(1) # Or 0, depending on your Raspberry Pi version
+
+    # Initialize PCA9685
+    pca = PCA9685(bus)
+
+    # Set PWM frequency to 60hz
+    pca.set_pwm_freq(60)
+
+    # Set a PWM channel to a specific value
+    # For example, channel 0 with a 50% duty cycle
+    # The PCA9685 has 4096 steps (12-bit)
+    # 50% of 4096 is 2048
+    channel = 0
+    on_tick = 0
+    off_tick = 2048
+    pca.set_pwm(channel, on_tick, off_tick)
+
+    time.sleep(1)
+
+    # Set all PWM channels to off
+    pca.set_all_pwm(0, 0)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+## I2C Dependency
+
+This library relies on an I2C interface object that provides `writeto_mem(address, register, buffer)` and `readfrom_mem(address, register, size)` methods. A common library that provides this interface is `smbus2` for Raspberry Pi.

--- a/pca9685/__init__.py
+++ b/pca9685/__init__.py
@@ -1,0 +1,1 @@
+from .driver import PCA9685

--- a/pca9685/driver.py
+++ b/pca9685/driver.py
@@ -1,0 +1,62 @@
+import time
+
+# Registers
+MODE1 = 0x00
+MODE2 = 0x01
+SUBADR1 = 0x02
+SUBADR2 = 0x03
+SUBADR3 = 0x04
+ALLCALLADR = 0x05
+LED0_ON_L = 0x06
+LED0_ON_H = 0x07
+LED0_OFF_L = 0x08
+LED0_OFF_H = 0x09
+ALL_LED_ON_L = 0xFA
+ALL_LED_ON_H = 0xFB
+ALL_LED_OFF_L = 0xFC
+ALL_LED_OFF_H = 0xFD
+PRESCALE = 0xFE
+
+# Bits
+RESTART = 0x80
+SLEEP = 0x10
+ALLCALL = 0x01
+INVRT = 0x10
+OUTDRV = 0x04
+
+
+class PCA9685:
+    def __init__(self, i2c, address=0x40):
+        self.i2c = i2c
+        self.address = address
+        self.reset()
+
+    def reset(self):
+        self.i2c.writeto_mem(self.address, MODE1, bytearray([0x00]))
+
+    def set_pwm_freq(self, freq_hz):
+        prescaleval = 25000000.0    # 25MHz
+        prescaleval /= 4096.0       # 12-bit
+        prescaleval /= float(freq_hz)
+        prescaleval -= 1.0
+        prescale = int(prescaleval + 0.5)
+
+        oldmode = self.i2c.readfrom_mem(self.address, MODE1, 1)[0]
+        newmode = (oldmode & 0x7F) | SLEEP
+        self.i2c.writeto_mem(self.address, MODE1, bytearray([newmode]))
+        self.i2c.writeto_mem(self.address, PRESCALE, bytearray([prescale]))
+        self.i2c.writeto_mem(self.address, MODE1, bytearray([oldmode]))
+        time.sleep(0.005)
+        self.i2c.writeto_mem(self.address, MODE1, bytearray([oldmode | RESTART]))
+
+    def set_pwm(self, channel, on, off):
+        self.i2c.writeto_mem(self.address, LED0_ON_L + 4 * channel, bytearray([on & 0xFF]))
+        self.i2c.writeto_mem(self.address, LED0_ON_H + 4 * channel, bytearray([on >> 8]))
+        self.i2c.writeto_mem(self.address, LED0_OFF_L + 4 * channel, bytearray([off & 0xFF]))
+        self.i2c.writeto_mem(self.address, LED0_OFF_H + 4 * channel, bytearray([off >> 8]))
+
+    def set_all_pwm(self, on, off):
+        self.i2c.writeto_mem(self.address, ALL_LED_ON_L, bytearray([on & 0xFF]))
+        self.i2c.writeto_mem(self.address, ALL_LED_ON_H, bytearray([on >> 8]))
+        self.i2c.writeto_mem(self.address, ALL_LED_OFF_L, bytearray([off & 0xFF]))
+        self.i2c.writeto_mem(self.address, ALL_LED_OFF_H, bytearray([off >> 8]))


### PR DESCRIPTION
This commit introduces a new Python library for controlling the PCA9685 16-channel, 12-bit PWM I2C-bus driver.

The library includes:
- A `PCA9685` class to interface with the device.
- Methods to set the PWM frequency and control individual and all PWM channels.
- An example script demonstrating the usage of the library with a mock I2C class for testing without hardware.
- A README file with documentation and usage instructions.